### PR TITLE
Fix typo in NuGet package (x86, not x68)

### DIFF
--- a/build/SIL.Chorus.Mercurial.proj
+++ b/build/SIL.Chorus.Mercurial.proj
@@ -25,7 +25,7 @@
 			<NuGetPackageDir>$(MSBuildProjectDirectory)/../output</NuGetPackageDir>
 			<NuGetRuntimeFolderWin>$(NuGetBuildDir)/runtimes/win/native</NuGetRuntimeFolderWin>
 			<NuGetRuntimeFolderLinux64>$(NuGetBuildDir)/runtimes/linux-x64/native</NuGetRuntimeFolderLinux64>
-			<NuGetRuntimeFolderLinux32>$(NuGetBuildDir)/runtimes/linux-x68/native</NuGetRuntimeFolderLinux32>
+			<NuGetRuntimeFolderLinux32>$(NuGetBuildDir)/runtimes/linux-x86/native</NuGetRuntimeFolderLinux32>
 			<NuGetRuntimeAnyFolder>$(NuGetBuildDir)/runtimes/any</NuGetRuntimeAnyFolder>
 		</PropertyGroup>
 		<ItemGroup>


### PR DESCRIPTION
The 3.0.1-beta2 version of the NuGet package contains a `runtimes/linux-x68` folder that should have been `runtimes/linux-x86`. This PR should fix that.