### PR TITLE
Explicitly request Python 2

### DIFF
--- a/linux-x64/Mercurial/hg
+++ b/linux-x64/Mercurial/hg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # mercurial - scalable distributed SCM
 #

--- a/linux-x86/Mercurial/hg
+++ b/linux-x86/Mercurial/hg
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # mercurial - scalable distributed SCM
 #


### PR DESCRIPTION
Our version of Mercurial requires python version 2 to run. Starting with Ubuntu 20.04 the installed python defaults to version 3. This
change explicitly calls python2 so that we run with the correct version. `/usr/bin/python2` is available at least since Ubuntu 18.04,
so this shouldn't cause problems on the currently supported systems.