### PR TITLE
Allow extraction to a custom location

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Mercurial version that Chorus uses. Mercurial is provided in the form of a nuget
 [SIL.Chorus.Mercurial](https://www.nuget.org/packages/SIL.Chorus.Mercurial).
 
 After installation of the nuget package the `Mercurial` and `MercurialExtensions` folders will be
-copied to the solution's directory during the build. Alternatively, specify `Mercurial4ChorusExctractionDir`
+copied to the solution's directory during the build. Alternatively, specify `Mercurial4ChorusDestDir`
 to copy into instead of the solution's directory.
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Mercurial version that Chorus uses. Mercurial is provided in the form of a nuget
 [SIL.Chorus.Mercurial](https://www.nuget.org/packages/SIL.Chorus.Mercurial).
 
 After installation of the nuget package the `Mercurial` and `MercurialExtensions` folders will be
-copied to the solutions directory during the build.
+copied to the solution's directory during the build. Alternatively, specify `Mercurial4ChorusExctractionDir`
+to copy into instead of the solution's directory.
 
 ## Building
 

--- a/assets/SIL.Chorus.Mercurial.targets
+++ b/assets/SIL.Chorus.Mercurial.targets
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<RuntimesDirectory>$(MSBuildThisFileDirectory)\..\runtimes</RuntimesDirectory>
 		<!-- Allow extraction to a custom location -->
-		<Mercurial4ChorusParentDir Condition="'$(Mercurial4ChorusParentDir)'==''">$(SolutionDir)</Mercurial4ChorusParentDir>
+		<Mercurial4ChorusExctractionDir Condition="'$(Mercurial4ChorusExctractionDir)'==''">$(SolutionDir)</Mercurial4ChorusExctractionDir>
 		<!-- Make CopyFiles target actually get executed.-->
 		<BuildDependsOn>$(BuildDependsOn);CopyFiles;AdjustFixUtf8</BuildDependsOn>
 	</PropertyGroup>
@@ -25,18 +25,18 @@
 			<AllFiles Include="$(RuntimesDirectory)\$(Platform)\native\**\*.*" />
 			<AllFiles Include="$(RuntimesDirectory)\any\**\*.*" />
 		</ItemGroup>
-		<Copy SourceFiles="@(AllFiles)" DestinationFolder="$(Mercurial4ChorusParentDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
+		<Copy SourceFiles="@(AllFiles)" DestinationFolder="$(Mercurial4ChorusExctractionDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
 	</Target>
 
 	<Target Name="AdjustFixUtf8" DependsOnTargets="CopyFiles">
 		<!-- Append fixutf8 line to mercurial.ini with correct path -->
-		<WriteLinesToFile File="$(Mercurial4ChorusParentDir)/Mercurial/mercurial.ini" Overwrite="false"
-			Lines="fixutf8 = $([System.IO.Path]::Combine($(Mercurial4ChorusParentDir),'MercurialExtensions','fixutf8','fixutf8.py'))" />
+		<WriteLinesToFile File="$(Mercurial4ChorusExctractionDir)/Mercurial/mercurial.ini" Overwrite="false"
+			Lines="fixutf8 = $([System.IO.Path]::Combine($(Mercurial4ChorusExctractionDir),'MercurialExtensions','fixutf8','fixutf8.py'))" />
 	</Target>
 
 	<Target Name="AdjustCacerts" DependsOnTargets="CopyFiles" Condition="'$(OS)'=='Windows_NT'">
 		<!-- Append cacerts line to cacerts.rc with the correct path -->
-		<WriteLinesToFile File="$(Mercurial4ChorusParentDir)/Mercurial/default.d/cacerts.rc" Overwrite="false"
-			Lines="cacerts=$([System.IO.Path]::Combine($(Mercurial4ChorusParentDir),'Mercurial','cacert.pem'))" />
+		<WriteLinesToFile File="$(Mercurial4ChorusExctractionDir)/Mercurial/default.d/cacerts.rc" Overwrite="false"
+			Lines="cacerts=$([System.IO.Path]::Combine($(Mercurial4ChorusExctractionDir),'Mercurial','cacert.pem'))" />
 	</Target>
 </Project>

--- a/assets/SIL.Chorus.Mercurial.targets
+++ b/assets/SIL.Chorus.Mercurial.targets
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<RuntimesDirectory>$(MSBuildThisFileDirectory)\..\runtimes</RuntimesDirectory>
 		<!-- Allow extraction to a custom location -->
-		<Mercurial4ChorusExctractionDir Condition="'$(Mercurial4ChorusExctractionDir)'==''">$(SolutionDir)</Mercurial4ChorusExctractionDir>
+		<Mercurial4ChorusDestDir Condition="'$(Mercurial4ChorusDestDir)'==''">$(SolutionDir)</Mercurial4ChorusDestDir>
 		<!-- Make CopyFiles target actually get executed.-->
 		<BuildDependsOn>$(BuildDependsOn);CopyFiles;AdjustFixUtf8</BuildDependsOn>
 	</PropertyGroup>
@@ -25,18 +25,18 @@
 			<AllFiles Include="$(RuntimesDirectory)\$(Platform)\native\**\*.*" />
 			<AllFiles Include="$(RuntimesDirectory)\any\**\*.*" />
 		</ItemGroup>
-		<Copy SourceFiles="@(AllFiles)" DestinationFolder="$(Mercurial4ChorusExctractionDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
+		<Copy SourceFiles="@(AllFiles)" DestinationFolder="$(Mercurial4ChorusDestDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
 	</Target>
 
 	<Target Name="AdjustFixUtf8" DependsOnTargets="CopyFiles">
 		<!-- Append fixutf8 line to mercurial.ini with correct path -->
-		<WriteLinesToFile File="$(Mercurial4ChorusExctractionDir)/Mercurial/mercurial.ini" Overwrite="false"
-			Lines="fixutf8 = $([System.IO.Path]::Combine($(Mercurial4ChorusExctractionDir),'MercurialExtensions','fixutf8','fixutf8.py'))" />
+		<WriteLinesToFile File="$(Mercurial4ChorusDestDir)/Mercurial/mercurial.ini" Overwrite="false"
+			Lines="fixutf8 = $([System.IO.Path]::Combine($(Mercurial4ChorusDestDir),'MercurialExtensions','fixutf8','fixutf8.py'))" />
 	</Target>
 
 	<Target Name="AdjustCacerts" DependsOnTargets="CopyFiles" Condition="'$(OS)'=='Windows_NT'">
 		<!-- Append cacerts line to cacerts.rc with the correct path -->
-		<WriteLinesToFile File="$(Mercurial4ChorusExctractionDir)/Mercurial/default.d/cacerts.rc" Overwrite="false"
-			Lines="cacerts=$([System.IO.Path]::Combine($(Mercurial4ChorusExctractionDir),'Mercurial','cacert.pem'))" />
+		<WriteLinesToFile File="$(Mercurial4ChorusDestDir)/Mercurial/default.d/cacerts.rc" Overwrite="false"
+			Lines="cacerts=$([System.IO.Path]::Combine($(Mercurial4ChorusDestDir),'Mercurial','cacert.pem'))" />
 	</Target>
 </Project>

--- a/assets/SIL.Chorus.Mercurial.targets
+++ b/assets/SIL.Chorus.Mercurial.targets
@@ -1,10 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<RuntimesDirectory>$(MSBuildThisFileDirectory)\..\runtimes</RuntimesDirectory>
-	</PropertyGroup>
-
-	<!-- Make CopyFiles target actually get executed.-->
-	<PropertyGroup>
+		<!-- Allow extraction to a custom location -->
+		<Mercurial4ChorusParentDir Condition="'$(Mercurial4ChorusParentDir)'==''">$(SolutionDir)</Mercurial4ChorusParentDir>
+		<!-- Make CopyFiles target actually get executed.-->
 		<BuildDependsOn>$(BuildDependsOn);CopyFiles;AdjustFixUtf8</BuildDependsOn>
 	</PropertyGroup>
 
@@ -26,18 +25,18 @@
 			<AllFiles Include="$(RuntimesDirectory)\$(Platform)\native\**\*.*" />
 			<AllFiles Include="$(RuntimesDirectory)\any\**\*.*" />
 		</ItemGroup>
-		<Copy SourceFiles="@(AllFiles)" DestinationFolder="$(SolutionDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
+		<Copy SourceFiles="@(AllFiles)" DestinationFolder="$(Mercurial4ChorusParentDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
 	</Target>
 
 	<Target Name="AdjustFixUtf8" DependsOnTargets="CopyFiles">
 		<!-- Append fixutf8 line to mercurial.ini with correct path -->
-		<WriteLinesToFile File="$(SolutionDir)/Mercurial/mercurial.ini" Overwrite="false"
-			Lines="fixutf8 = $([System.IO.Path]::Combine($(SolutionDir),'MercurialExtensions','fixutf8','fixutf8.py'))" />
+		<WriteLinesToFile File="$(Mercurial4ChorusParentDir)/Mercurial/mercurial.ini" Overwrite="false"
+			Lines="fixutf8 = $([System.IO.Path]::Combine($(Mercurial4ChorusParentDir),'MercurialExtensions','fixutf8','fixutf8.py'))" />
 	</Target>
 
 	<Target Name="AdjustCacerts" DependsOnTargets="CopyFiles" Condition="'$(OS)'=='Windows_NT'">
 		<!-- Append cacerts line to cacerts.rc with the correct path -->
-		<WriteLinesToFile File="$(SolutionDir)/Mercurial/default.d/cacerts.rc" Overwrite="false"
-			Lines="cacerts=$([System.IO.Path]::Combine($(SolutionDir),'Mercurial','cacert.pem'))" />
+		<WriteLinesToFile File="$(Mercurial4ChorusParentDir)/Mercurial/default.d/cacerts.rc" Overwrite="false"
+			Lines="cacerts=$([System.IO.Path]::Combine($(Mercurial4ChorusParentDir),'Mercurial','cacert.pem'))" />
 	</Target>
 </Project>


### PR DESCRIPTION
WeSay's solution is in the src directory, which is a sibling
of the Output directory. Chorus, when searching for Mercurial,
will look in parent directories of the executing assembly's
directory. Since WeSay's SolutionDir is not a parent of the
output dir, Mercurial won't be found. This will allow WeSay
and similar projects to specify a custom location that will
be found.