### PR TITLE
Fix Linux Mercurial4Chorus package

### DIFF
--- a/linux-x64/Mercurial/hgdemandimport/__init__.py
+++ b/linux-x64/Mercurial/hgdemandimport/__init__.py
@@ -1,0 +1,86 @@
+# hgdemandimport - global demand-loading of modules for Mercurial
+#
+# Copyright 2017 Facebook Inc.
+#
+# This software may be used and distributed according to the terms of the
+# GNU General Public License version 2 or any later version.
+
+'''demandimport - automatic demand-loading of modules'''
+
+# This is in a separate package from mercurial because in Python 3,
+# demand loading is per-package. Keeping demandimport in the mercurial package
+# would disable demand loading for any modules in mercurial.
+
+
+import os
+import sys
+
+from . import demandimportpy3 as demandimport
+
+# Full module names which can't be lazy imported.
+# Extensions can add to this set.
+IGNORES = {
+    '__future__',
+    '_hashlib',
+    # ImportError during pkg_resources/__init__.py:fixup_namespace_package
+    '_imp',
+    '_xmlplus',
+    'fcntl',
+    'nt',  # pathlib2 tests the existence of built-in 'nt' module
+    'win32com.gen_py',
+    'win32com.shell',  # 'appdirs' tries to import win32com.shell
+    '_winreg',  # 2.7 mimetypes needs immediate ImportError
+    'pythoncom',
+    # imported by tarfile, not available under Windows
+    'pwd',
+    'grp',
+    # imported by profile, itself imported by hotshot.stats,
+    # not available under Windows
+    'resource',
+    # this trips up many extension authors
+    'gtk',
+    # setuptools' pkg_resources.py expects "from __main__ import x" to
+    # raise ImportError if x not defined
+    '__main__',
+    '_ast',  # https://bugs.python.org/issue41631
+    '_ssl',  # conditional imports in the stdlib, issue1964
+    '_sre',  # issue4920
+    'rfc822',
+    'mimetools',
+    'sqlalchemy.events',  # has import-time side effects (issue5085)
+    'sqlalchemy.dialects',  # similar problems as above
+    # setuptools 8 expects this module to explode early when not on windows
+    'distutils.msvc9compiler',
+    '__builtin__',
+    'builtins',
+    'urwid.command_map',  # for pudb
+    'lzma',
+    # setuptools uses this hack to inject it's own distutils at import time
+    'setuptools',
+    '_distutils_hack.override',
+}
+
+_pypy = '__pypy__' in sys.builtin_module_names
+
+if _pypy:
+    # _ctypes.pointer is shadowed by "from ... import pointer" (PyPy 5)
+    IGNORES.add('_ctypes.pointer')
+    # pure Python module on PyPy, must be loaded to raise ModuleNotFoundError
+    # on non-Windows platforms
+    IGNORES.add('msvcrt')
+
+demandimport.init(IGNORES)
+
+# Re-export.
+isenabled = demandimport.isenabled
+disable = demandimport.disable
+deactivated = demandimport.deactivated
+
+
+def enable():
+    # chg pre-imports modules so do not enable demandimport for it
+    if (
+        'CHGINTERNALMARK' not in os.environ
+        and os.environ.get('HGDEMANDIMPORT') != 'disable'
+    ):
+        demandimport.enable()

--- a/linux-x64/Mercurial/hgdemandimport/demandimportpy3.py
+++ b/linux-x64/Mercurial/hgdemandimport/demandimportpy3.py
@@ -1,0 +1,178 @@
+# demandimportpy3 - global demand-loading of modules for Mercurial
+#
+# Copyright 2017 Facebook Inc.
+#
+# This software may be used and distributed according to the terms of the
+# GNU General Public License version 2 or any later version.
+
+"""Lazy loading for Python 3.6 and above.
+
+This uses the new importlib finder/loader functionality available in Python 3.5
+and up. The code reuses most of the mechanics implemented inside importlib.util,
+but with a few additions:
+
+* Allow excluding certain modules from lazy imports.
+* Expose an interface that's substantially the same as demandimport for
+  Python 2.
+
+This also has some limitations compared to the Python 2 implementation:
+
+* Much of the logic is per-package, not per-module, so any packages loaded
+  before demandimport is enabled will not be lazily imported in the future. In
+  practice, we only expect builtins to be loaded before demandimport is
+  enabled.
+"""
+
+import contextlib
+import importlib.util
+import sys
+
+from . import tracing
+
+_deactivated = False
+
+
+class _lazyloaderex(importlib.util.LazyLoader):
+    """This is a LazyLoader except it also follows the _deactivated global and
+    the ignore list.
+    """
+
+    _HAS_DYNAMIC_ATTRIBUTES = True  # help pytype not flag self.loader
+
+    def exec_module(self, module):
+        """Make the module load lazily."""
+        with tracing.log('demandimport %s', module):
+            if _deactivated or module.__name__ in ignores:
+                # Reset the loader on the module as super() does (issue6725)
+                module.__spec__.loader = self.loader
+                module.__loader__ = self.loader
+
+                self.loader.exec_module(module)
+            else:
+                super().exec_module(module)
+
+
+class LazyFinder:
+    """A wrapper around a ``MetaPathFinder`` that makes loaders lazy.
+
+    ``sys.meta_path`` finders have their ``find_spec()`` called to locate a
+    module. This returns a ``ModuleSpec`` if found or ``None``. The
+    ``ModuleSpec`` has a ``loader`` attribute, which is called to actually
+    load a module.
+
+    Our class wraps an existing finder and overloads its ``find_spec()`` to
+    replace the ``loader`` with our lazy loader proxy.
+
+    We have to use __getattribute__ to proxy the instance because some meta
+    path finders don't support monkeypatching.
+    """
+
+    __slots__ = ("_finder",)
+
+    def __init__(self, finder):
+        object.__setattr__(self, "_finder", finder)
+
+    def __repr__(self):
+        return "<LazyFinder for %r>" % object.__getattribute__(self, "_finder")
+
+    # __bool__ is canonical Python 3. But check-code insists on __nonzero__ being
+    # defined via `def`.
+    def __nonzero__(self):
+        return bool(object.__getattribute__(self, "_finder"))
+
+    __bool__ = __nonzero__
+
+    def __getattribute__(self, name):
+        if name in ("_finder", "find_spec"):
+            return object.__getattribute__(self, name)
+
+        return getattr(object.__getattribute__(self, "_finder"), name)
+
+    def __delattr__(self, name):
+        return delattr(object.__getattribute__(self, "_finder"), name)
+
+    def __setattr__(self, name, value):
+        return setattr(object.__getattribute__(self, "_finder"), name, value)
+
+    def find_spec(self, fullname, path, target=None):
+        finder = object.__getattribute__(self, "_finder")
+        try:
+            find_spec = finder.find_spec
+        except AttributeError:
+            loader = finder.find_module(fullname, path)
+            if loader is None:
+                spec = None
+            else:
+                spec = importlib.util.spec_from_loader(fullname, loader)
+        else:
+            spec = find_spec(fullname, path, target)
+
+        # Lazy loader requires exec_module().
+        if (
+            spec is not None
+            and spec.loader is not None
+            and getattr(spec.loader, "exec_module", None)
+        ):
+            spec.loader = _lazyloaderex(spec.loader)
+
+        return spec
+
+
+ignores = set()
+
+
+def init(ignoreset):
+    global ignores
+    ignores = ignoreset
+
+
+def isenabled():
+    return not _deactivated and any(
+        isinstance(finder, LazyFinder) for finder in sys.meta_path
+    )
+
+
+def disable():
+    new_finders = []
+    for finder in sys.meta_path:
+        new_finders.append(
+            finder._finder if isinstance(finder, LazyFinder) else finder
+        )
+    sys.meta_path[:] = new_finders
+
+
+def enable():
+    new_finders = []
+    for finder in sys.meta_path:
+        new_finders.append(
+            LazyFinder(finder) if not isinstance(finder, LazyFinder) else finder
+        )
+    sys.meta_path[:] = new_finders
+
+
+@contextlib.contextmanager
+def deactivated():
+    # This implementation is a bit different from Python 2's. Python 3
+    # maintains a per-package finder cache in sys.path_importer_cache (see
+    # PEP 302). This means that we can't just call disable + enable.
+    # If we do that, in situations like:
+    #
+    #   demandimport.enable()
+    #   ...
+    #   from foo.bar import mod1
+    #   with demandimport.deactivated():
+    #       from foo.bar import mod2
+    #
+    # mod2 will be imported lazily. (The converse also holds -- whatever finder
+    # first gets cached will be used.)
+    #
+    # Instead, have a global flag the LazyLoader can use.
+    global _deactivated
+    demandenabled = isenabled()
+    if demandenabled:
+        _deactivated = True
+    try:
+        yield
+    finally:
+        if demandenabled:
+            _deactivated = False

--- a/linux-x64/Mercurial/hgdemandimport/tracing.py
+++ b/linux-x64/Mercurial/hgdemandimport/tracing.py
@@ -1,0 +1,61 @@
+# Support code for event tracing in Mercurial. Lives in demandimport
+# so it can also be used in demandimport.
+#
+# Copyright 2018 Google LLC.
+#
+# This software may be used and distributed according to the terms of the
+# GNU General Public License version 2 or any later version.
+
+import contextlib
+import os
+
+_pipe = None
+_checked = False
+_session = 'none'
+
+
+def _isactive():
+    global _pipe, _session, _checked
+    if _pipe is None:
+        if _checked:
+            return False
+        _checked = True
+        if 'HGCATAPULTSERVERPIPE' not in os.environ:
+            return False
+        _pipe = open(os.environ['HGCATAPULTSERVERPIPE'], 'w', 1)
+        _session = os.environ.get('HGCATAPULTSESSION', 'none')
+    return True
+
+
+@contextlib.contextmanager
+def log(whencefmt, *whenceargs):
+    if not _isactive():
+        yield
+        return
+    whence = whencefmt % whenceargs
+    try:
+        # Both writes to the pipe are wrapped in try/except to ignore
+        # errors, as we can see mysterious errors in here if the pager
+        # is active. Presumably other conditions could trigger
+        # problems too.
+        try:
+            _pipe.write('START %s %s\n' % (_session, whence))
+        except IOError:
+            pass
+        yield
+    finally:
+        try:
+            _pipe.write('END %s %s\n' % (_session, whence))
+        except IOError:
+            pass
+
+
+def counter(label, amount, *labelargs):
+    if not _isactive():
+        return
+    l = label % labelargs
+    # See above in log() for why this is in a try/except.
+    try:
+        _pipe.write('COUNTER %s %d %s\n' % (_session, amount, l))
+    except IOError:
+        pass


### PR DESCRIPTION
Some vital Mercurial files were accidentally left out, and without these it won't start (unless system Mercurial is available, which is how this was missed originally).