### PR TITLE
New workflow to build Mercurial in GHA runner

### DIFF
--- a/.github/workflows/build-hg.yml
+++ b/.github/workflows/build-hg.yml
@@ -1,0 +1,78 @@
+name: Build Mercurial
+run-name: Build Mercurial ${{ inputs.hg-version }}
+
+on:
+  # Run manually
+  workflow_dispatch:
+    inputs:
+      hg-version:
+        description: 'Mercurial version to build'
+        required: false
+        type: string
+        default: '6.5.1'
+
+jobs:
+  build-python:
+    # Use specific Ubuntu version rather than ubuntu-latest, so we can control when to upgrade the runner
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    steps:
+    - name: Setup Python
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+    - name: Install Python setuptools
+      run: pip install setuptools
+    - name: Checkout Mercurial
+      run: hg clone https://repo.mercurial-scm.org/hg
+    - name: Checkout hg version to build
+      run: hg checkout "${VER}"
+      working-directory: hg
+      env:
+        VER: ${{ inputs.hg-version }}
+    - name: Build Mercurial
+      run: make local
+      working-directory: hg
+    - name: Delete .hg folder prior to upload
+      run: rm -rf .hg
+      working-directory: hg
+    - name: Upload Mercurial build results
+      uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
+      with:
+        name: hg-for-python-${{ matrix.python-version }}
+        path: |
+          hg/contrib
+          hg/COPYING
+          hg/hg
+          hg/hgdemandimport
+          hg/hgext
+          hg/mercurial
+        if-no-files-found: error
+
+  combine:
+    runs-on: ubuntu-latest
+    needs: build-python
+    steps:
+
+    - name: Combine Mercurial builds
+      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d # v4.1.5
+      with:
+        path: .
+        pattern: hg-for-python-*
+        merge-multiple: true
+
+    - name: Upload combined build
+      uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
+      with:
+        name: mercurial-${{ inputs.hg-version }}
+        path: .
+        if-no-files-found: error

--- a/.github/workflows/build-hg.yml
+++ b/.github/workflows/build-hg.yml
@@ -26,7 +26,7 @@ jobs:
           - "3.13"
     steps:
     - name: Setup Python
-      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -46,7 +46,7 @@ jobs:
       run: rm -rf .hg
       working-directory: hg
     - name: Upload Mercurial build results
-      uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
+      uses: actions/upload-artifact@v4
       with:
         name: hg-for-python-${{ matrix.python-version }}
         path: |
@@ -64,14 +64,14 @@ jobs:
     steps:
 
     - name: Combine Mercurial builds
-      uses: actions/download-artifact@8caf195ad4b1dee92908e23f56eeb0696f1dd42d # v4.1.5
+      uses: actions/download-artifact@v4
       with:
         path: .
         pattern: hg-for-python-*
         merge-multiple: true
 
     - name: Upload combined build
-      uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
+      uses: actions/upload-artifact@v4
       with:
         name: mercurial-${{ inputs.hg-version }}
         path: .


### PR DESCRIPTION
This will allow us to easily compile Mercurial C extensions against all versions of Python 3 currently supported, including alpha releases. That way the Linux NuGet package will be able to run on current and future Ubuntu releases, no matter which version of Python becomes the default.

Due to the nature of GitHub Actions workflows it's hard to test this before merging, but you can see a successful run of this workflow in https://github.com/rmunn/Testing/actions/runs/8778565223 and download the mercurial-6.5.1.zip artifact to see the results.