### PR TITLE
Update upload-artifact & checkout action versions

### DIFF
--- a/.github/workflows/nuget-ci-cd.yml
+++ b/.github/workflows/nuget-ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       with:
         fetch-depth: 0
     - name: Set Beta Version
@@ -34,7 +34,7 @@ jobs:
       run: dotnet msbuild -target:Build build/SIL.Chorus.Mercurial.proj -property:PreRelease=${{ env.release-suffix }} -property:BuildCounter=${{ github.run_number }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
       with:
         name: packages
         path: ./**/*.nupkg

--- a/.github/workflows/nuget-ci-cd.yml
+++ b/.github/workflows/nuget-ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set Beta Version
@@ -34,7 +34,7 @@ jobs:
       run: dotnet msbuild -target:Build build/SIL.Chorus.Mercurial.proj -property:PreRelease=${{ env.release-suffix }} -property:BuildCounter=${{ github.run_number }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
+      uses: actions/upload-artifact@v4
       with:
         name: packages
         path: ./**/*.nupkg


### PR DESCRIPTION
Fixes #19.

The workflow currently uses upload-artifact v2, which is deprecated and will go away on 2024-06-30. In fact, v3 will go away on 2024-10-30 as well; we need to jump straight to v4. While we're updating long-out-of-date action versions, we should also update actions/checkout as well, as v2.3.4 is about three and a half years old at this point.

Using SHAs rather than version tags as this is [GitHub's recommended best practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions, and there's no particular reason not to do so for official GitHub-created actions either.